### PR TITLE
New setting for hemisphere and code adjustment to invert moon phases …

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -26,6 +26,7 @@
     <property id="dateAlignment" type="number">0</property>
     <property id="dateFormat" type="number">0</property>
     <property id="smallFontVariant" type="number">2</property>
+    <property id="hemisphere" type="number">0</property>
     <property id="tzOffset1" type="number">0</property>
     <property id="tzOffset2" type="number">0</property>
     <property id="tzName1" type="string">UTC TIME</property>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -122,7 +122,12 @@
                 <listEntry value="2">Lines (highest contrast)</listEntry>
             </settingConfig>
     </setting>
-
+    <setting propertyKey="@Properties.hemisphere" title="Hemisphere (for Moon icon)">
+            <settingConfig type="list">
+                <listEntry value="0">Northern</listEntry>
+                <listEntry value="1">Southern</listEntry>
+            </settingConfig>
+        </setting>
     <setting propertyKey="@Properties.hourFormat" title="Time format (12/24h)">
         <settingConfig type="list">
             <listEntry value="0">Auto - Use system setting</listEntry>
@@ -130,7 +135,6 @@
             <listEntry value="2">12h</listEntry>
         </settingConfig>
     </setting>
-
     <setting propertyKey="@Properties.dateFormat" title="Date format">
         <settingConfig type="list">
             <listEntry value="0">WEEKDAY, DD MONTH YYYY</listEntry>

--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -2485,30 +2485,48 @@ class Segment34View extends WatchUi.WatchFace {
         var lunar_cycle = 29.53;
         var phase = ((days_since_new_moon / lunar_cycle) * 100).toNumber() % 100;
         var into_cycle = (phase / 100.0) * lunar_cycle;
+        var hemisphere = Application.Properties.getValue("hemisphere");
 
         if(time.month == 5 and time.day == 4) {
             return "8"; // That's no moon!
         }
 
-        if (into_cycle < 3) { // 2+1
-            return "0";
-        } else if (into_cycle < 6) { // 4
-            return "1";
-        } else if (into_cycle < 10) { // 4
-            return "2";
-        } else if (into_cycle < 14) { // 4
-            return "3";
-        } else if (into_cycle < 18) { // 4
-            return "4";
-        } else if (into_cycle < 22) { // 4
-            return "5";
-        } else if (into_cycle < 26) { // 4
-            return "6";
-        } else if (into_cycle < 29) { // 3
-            return "7";
-        } else {
-            return "0";
-        }
+       var moonPhase;
+            if (into_cycle < 3) { // 2+1
+                moonPhase = 0;
+            } else if (into_cycle < 6) { // 4
+                moonPhase = 1;
+            } else if (into_cycle < 10) { // 4
+                moonPhase = 2;
+            } else if (into_cycle < 14) { // 4
+                moonPhase = 3;
+            } else if (into_cycle < 18) { // 4
+                moonPhase = 4;
+            } else if (into_cycle < 22) { // 4
+                moonPhase = 5;
+            } else if (into_cycle < 26) { // 4
+                moonPhase = 6;
+            } else if (into_cycle < 29) { // 3
+                moonPhase = 7;
+            } else {
+                moonPhase = 0;
+            }
+
+        // If hemisphere is 1 (southern), invert the phase index
+       if (hemisphere == 1) {
+            switch (moonPhase.toString()) {
+                case "1": moonPhase = 7; break; // waxing crescent ↔ waning crescent
+                case "2": moonPhase = 6; break; // first quarter ↔ last quarter
+                case "3": moonPhase = 5; break; // waxing gibbous ↔ waning gibbous
+                case "4": moonPhase = 4; break; // full moon remains unchanged
+                case "5": moonPhase = 3; break; // waning gibbous ↔ waxing gibbous
+                case "6": moonPhase = 2; break; // last quarter ↔ first quarter
+                case "7": moonPhase = 1; break; // waning crescent ↔ waxing crescent
+                // "0" (new) and "4" (full) remain unchanged
+            }
+}
+
+        return moonPhase.toString();
 
     }
 


### PR DESCRIPTION
Currently the moon icons are not displayed correctly in southern hemisphere. In the [Southern Hemisphere](https://en.wikipedia.org/wiki/Southern_Hemisphere), the Moon is observed from a perspective inverted, or rotated 180°, to that of the Northern and to all of the images in this watchface, so that the opposite sides appear to wax or wane.

This pull request is my attempt to fix it by adding a Norther/Southern config option, and if it is in the southern hemisphere, then invert the moon icons.
Please review as I have not developed Garmin apps before.
Thank you