### PR TITLE
added next sun event time

### DIFF
--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -94,6 +94,7 @@
                 <listEntry value="-2">Hidden</listEntry>
                 <listEntry value="39">Sunrise time</listEntry>
                 <listEntry value="40">Sunset time</listEntry>
+                <listEntry value="55">Next sun event time</listEntry>
                 <listEntry value="4">Floors climbed / day</listEntry>
                 <listEntry value="5">Meters climbed / day</listEntry>
                 <listEntry value="6">Time to Recovery (h)</listEntry>
@@ -125,6 +126,7 @@
                 <listEntry value="-2">Hidden</listEntry>
                 <listEntry value="39">Sunrise time</listEntry>
                 <listEntry value="40">Sunset time</listEntry>
+                <listEntry value="55">Next sun event time</listEntry>
                 <listEntry value="4">Floors climbed / day</listEntry>
                 <listEntry value="5">Meters climbed / day</listEntry>
                 <listEntry value="6">Time to Recovery (h)</listEntry>
@@ -375,6 +377,7 @@
             <listEntry value="14">Body battery</listEntry>
             <listEntry value="39">Sunrise time</listEntry>
             <listEntry value="40">Sunset time</listEntry>
+            <listEntry value="55">Next sun event time</listEntry>
             <listEntry value="16">Alternative Timezone 1</listEntry>
             <listEntry value="41">Alternative Timezone 2</listEntry>
             <listEntry value="26">Barometric Pressure, raw</listEntry>
@@ -421,6 +424,7 @@
             <listEntry value="14">Body battery</listEntry>
             <listEntry value="39">Sunrise time</listEntry>
             <listEntry value="40">Sunset time</listEntry>
+            <listEntry value="55">Next sun event time</listEntry>
             <listEntry value="16">Alternative Timezone 1</listEntry>
             <listEntry value="41">Alternative Timezone 2</listEntry>
             <listEntry value="27">Weight (kg)</listEntry>
@@ -467,6 +471,7 @@
             <listEntry value="14">Body battery</listEntry>
             <listEntry value="39">Sunrise time</listEntry>
             <listEntry value="40">Sunset time</listEntry>
+            <listEntry value="55">Next sun event time</listEntry>
             <listEntry value="16">Alternative Timezone 1</listEntry>
             <listEntry value="41">Alternative Timezone 2</listEntry>
             <listEntry value="26">Barometric Pressure, raw</listEntry>

--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -2155,6 +2155,40 @@ class Segment34View extends WatchUi.WatchFace {
         } else if(complicationType == 54) { // Precipitation chance
             val = getPrecip();
             if(width == 3 and val.equals("100%")) { val = "100"; }
+        } else if(complicationType == 55) { // Next Sun Event
+            var now = Time.now();
+            if(weatherCondition != null) {
+                var loc = weatherCondition.observationLocationPosition;
+                if(loc != null) {
+                    var nextSunEvent = null;
+                    var sunrise = Weather.getSunrise(loc, now);
+                    var sunset = Weather.getSunset(loc, now);
+                    
+                    if ((sunrise != null) && (sunset != null)) {
+                        if (sunrise.lessThan(now)) { 
+                            //if sunrise was already, take tomorrows
+                            sunrise = Weather.getSunrise(loc, Time.today().add(new Time.Duration(86401)));
+                        }
+                        if (sunset.lessThan(now)) { 
+                            //if sunset was already, take tomorrows
+                            sunset = Weather.getSunset(loc, Time.today().add(new Time.Duration(86401)));
+                        }
+                        if (sunrise.lessThan(sunset)) { 
+                            nextSunEvent = sunrise;
+                        }else{
+                            nextSunEvent = sunset;
+                        }
+                    }
+
+                    nextSunEvent = Time.Gregorian.info(nextSunEvent, Time.FORMAT_SHORT);
+                    var nextSunEventHour = formatHour(nextSunEvent.hour);
+                    if(width < 5) {
+                        val = Lang.format("$1$$2$", [nextSunEventHour.format("%02d"), nextSunEvent.min.format("%02d")]);
+                    } else {
+                        val = Lang.format("$1$:$2$", [nextSunEventHour.format("%02d"), nextSunEvent.min.format("%02d")]);
+                    }
+                }
+            }
         }
 
         return val;
@@ -2346,6 +2380,10 @@ class Segment34View extends WatchUi.WatchFace {
             if(labelSize == 1) { desc = "PRECIP:"; }
             if(labelSize == 2) { desc = "PRECIP:"; }
             if(labelSize == 3) { desc = "PRECIPITATION:"; }
+        } else if(complicationType == 55) {
+            if(labelSize == 1) { desc = "SUN:"; }
+            if(labelSize == 2) { desc = "NEXT SUN:"; }
+            if(labelSize == 3) { desc = "NEXT SUN EVENT:"; }
         }
         return desc;
     }


### PR DESCRIPTION
Added next sun event time for sunset, sunrise and bottom left, middle, and right. Field shows the next sun event (either sunrise or sunset) from "now". This means after sunset, it will take tomorrows sunrise for example. Tested CIQ SDK (mainly Fenix 7 Pro, but tested also for a few random others. It uses the weather.getSunrise and weather.getSunset function, i.e. as long as Sunset and Sunrise works, this will also work.