### PR TITLE
External labels and screen data

### DIFF
--- a/resources/json/label_texts.xml
+++ b/resources/json/label_texts.xml
@@ -1,0 +1,193 @@
+<resources xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://developer.garmin.com/downloads/connect-iq/resources.xsd">
+  <jsonData id="shortLabels">[
+      "W MIN:",         //  [0] Active min / week
+      "D MIN:",         //  [1] Active min / day
+      "D KM:",          //  [2] distance (km) / day
+      "D MI:",          //  [3] distance (miles) / day
+      "FLRS:",          //  [4] floors climbed / day
+      "CLIMB:",         //  [5] meters climbed / day
+      "RECOV:",         //  [6] Time to Recovery (h)
+      "V02:",           //  [7] VO2 Max Running
+      "V02:",           //  [8] VO2 Max Cycling
+      "RESP:",          //  [9] Respiration rate
+      "HR:",            // [10] Heart Rate
+      "CAL:",           // [11] Calories / day
+      "ALT:",           // [12] Altitude (m)
+      "STRSS:",         // [13] Stress
+      "B BAT:",         // [14] Body battery
+      "ALT:",           // [15] Altitude (ft)
+      "",               // [16] Alt TZ 1, done in function
+      "STEPS:",         // [17] Steps / day
+      "DIST:",          // [18] Distance (m) / day
+      "PUSHES:",        // [19] Wheelchair pushes
+      "",               // [20] Weather condition
+      "W KM:",          // [21] Weekly run distance (km)
+      "W MI:",          // [22] Weekly run distance (miles)
+      "W KM:",          // [23] Weekly bike distance (km)
+      "W MI:",          // [24] Weekly bike distance (miles)
+      "TRAINING:",      // [25] Training status
+      "PRESSURE:",      // [26] Barometric pressure (hPA)
+      "KG:",            // [27] Weight kg
+      "LBS:",           // [28] Weight lbs
+      "A CAL:",         // [29] Act Calories / day
+      "PRESSURE:",      // [30] Sea level pressure (hPA)
+      "WEEK:",          // [31] Week number
+      "W KM:",          // [32] Weekly distance (km)
+      "W MI:",          // [33] Weekly distance (miles)
+      "BATT:",          // [34] Battery percentage
+      "BATT D:",        // [35] Battery days remaining
+      "NOTIFS:",        // [36] Notification count
+      "SUN:",           // [37] Solar intensity
+      "TEMP:",          // [38] Sensor temp
+      "DAWN:",          // [39] Sunrise
+      "DUSK:",          // [40] Sunset
+      "",               // [41] Alt TZ 2:
+      "ALARM:",         // [42] Alarms
+      "HIGH:",          // [43] Daily high temp
+      "LOW:",           // [44] Daily low temp
+      "",               // [45] empty for offset 45
+      "",               // [46] empty for offset 46
+      "",               // [47] empty for offset 47
+      "",               // [48] empty for offset 48
+      "",               // [49] empty for offset 49
+      "",               // [50] empty for offset 50
+      "",               // [51] empty for offset 51
+      "",               // [52] empty for offset 52
+      "TEMP:",          // [53] Temperature
+      "PRECIP:",        // [54] Precipitation
+      "SUN:",           // [55] Next sun event
+      "",               // [56] empty for offset 56
+      "CAL:",           // [57] Time of the next Calendar Event
+      "",               // [58] empty for offset 58
+      "OX:"             // [59] Pulse Ox
+    ]
+    </jsonData>
+    <jsonData id="midLabels">[
+      "WEEK MIN:",    //  [0] Active min / week
+      "MIN TODAY:",   //  [1] Active min / day
+      "KM TODAY:",    //  [2] distance (km) / day
+      "MI TODAY:",    //  [3] distance (miles) / day
+      "FLOORS:",      //  [4] floors climbed / day
+      "M CLIMBED:",   //  [5] meters climbed / day
+      "RECOV HRS:",   //  [6] Time to Recovery (h)
+      "V02 MAX:",     //  [7] VO2 Max Running
+      "V02 MAX:",     //  [8] VO2 Max Cycling
+      "RESP RATE:",   //  [9] Respiration rate
+      "LAST HR:",     // [10] Heart Rate
+      "CALORIES:",    // [11] Calories / day
+      "ALTITUDE:",    // [12] Altitude (m)
+      "STRESS:",      // [13] Stress
+      "BODY BATT:",   // [14] Body battery
+      "ALTITUDE:",    // [15] Altitude (ft)
+      "",             // [16] Alt TZ 1, done in function
+      "STEPS:",       // [17] Steps / day
+      "M TODAY:",     // [18] Distance (m) / day
+      "PUSHES:",      // [19] Wheelchair pushes
+      "",             // [20] Weather condition
+      "W RUN KM:",    // [21] Weekly run distance (km)
+      "W RUN MI:",    // [22] Weekly run distance (miles)
+      "W BIKE KM:",   // [23] Weekly bike distance (km)
+      "W BIKE MI:",   // [24] Weekly bike distance (miles)
+      "TRAINING:",    // [25] Training status
+      "PRESSURE:",    // [26] Barometric pressure (hPA)
+      "WEIGHT:",      // [27] Weight kg
+      "WEIGHT:",      // [28] Weight lbs
+      "ACT. CAL:",    // [29] Act Calories / day
+      "PRESSURE:",    // [30] Sea level pressure (hPA)
+      "WEEK:",        // [31] Week number
+      "WEEK KM:",     // [32] Weekly distance (km)
+      "WEEK MI:",     // [33] Weekly distance (miles)
+      "BATT %:",      // [34] Battery percentage
+      "BATT DAYS:",   // [35] Battery days remaining
+      "NOTIFS:",      // [36] Notification count
+      "SUN INT:",     // [37] Solar intensity
+      "TEMP:",        // [38] Sensor temp
+      "SUNRISE:",     // [39] Sunrise
+      "SUNSET:",      // [40] Sunset
+      "",             // [41] Alt TZ 2:
+      "ALARMS:",      // [42] Alarms
+      "DAILY HIGH:",  // [43] Daily high temp
+      "DAILY LOW:",   // [44] Daily low temp
+      "",             // [45] empty for offset 45
+      "",             // [46] empty for offset 46
+      "",             // [47] empty for offset 47
+      "",             // [48] empty for offset 48
+      "",             // [49] empty for offset 49
+      "",             // [50] empty for offset 50
+      "",             // [51] empty for offset 51
+      "",             // [52] empty for offset 52
+      "TEMP:",        // [53] Temperature
+      "PRECIP:",      // [54] Precipitation
+      "NEXT SUN:",    // [55] Next sun event
+      "",             // [56] empty for offset 56
+      "NEXT CAL:",    // [57] Time of the next Calendar Event
+      "",             // [58] empty for offset 58
+      "PULSE OX:"     // [59] Pulse Ox
+      ]
+    </jsonData>
+    <jsonData id="longLabels">[
+      "WEEK ACT MIN:",   //  [0] Active min / week
+      "DAY ACT MIN:",    //  [1] Active min / day
+      "KM TODAY:",       //  [2] distance (km) / day
+      "MILES TODAY:",    //  [3] distance (miles) / day
+      "FLOORS:",         //  [4] floors climbed / day
+      "M CLIMBED:",      //  [5] meters climbed / day
+      "RECOVERY HRS:",   //  [6] Time to Recovery (h)
+      "RUN V02 MAX:",    //  [7] VO2 Max Running
+      "BIKE V02 MAX:",   //  [8] VO2 Max Cycling
+      "RESP. RATE:",     //  [9] Respiration rate
+      "LAST HR:",        // [10] Heart Rate
+      "DLY CALORIES:",   // [11] Calories / day
+      "ALTITUDE M:",     // [12] Altitude (m)
+      "STRESS:",         // [13] Stress
+      "BODY BATTERY:",   // [14] Body battery
+      "ALTITUDE FT:",    // [15] Altitude (ft)
+      "",                // [16] Alt TZ 1, done in function
+      "STEPS:",          // [17] Steps / day
+      "METERS TODAY:",   // [18] Distance (m) / day
+      "PUSHES:",         // [19] Wheelchair pushes
+      "",                // [20] Weather condition
+      "WEEK RUN KM:",    // [21] Weekly run distance (km)
+      "WEEK RUN MI:",    // [22] Weekly run distance (miles)
+      "WEEK BIKE KM:",   // [23] Weekly bike distance (km)
+      "WEEK BIKE MI:",   // [24] Weekly bike distance (miles)
+      "TRAINING:",       // [25] Training status
+      "PRESSURE:",       // [26] Barometric pressure (hPA)
+      "WEIGHT KG:",      // [27] Weight kg
+      "WEIGHT KG:",      // [28] Weight lbs
+      "ACT. CALORIES:",  // [29] Act Calories / day
+      "PRESSURE:",       // [30] Sea level pressure (hPA)
+      "WEEK:",           // [31] Week number
+      "WEEK DIST KM:",   // [32] Weekly distance (km)
+      "WEEKLY MILES:",   // [33] Weekly distance (miles)
+      "BATTERY %:",      // [34] Battery percentage
+      "BATTERY DAYS:",   // [35] Battery days remaining
+      "NOTIFICATIONS:",  // [36] Notification count
+      "SUN INTENSITY:",  // [37] Solar intensity
+      "SENSOR TEMP:",    // [38] Sensor temp
+      "SUNRISE:",        // [39] Sunrise
+      "SUNSET:",         // [40] Sunset
+      "",                // [41] Alt TZ 2:
+      "ALARMS:",         // [42] Alarms
+      "DAILY HIGH:",     // [43] Daily high temp
+      "DAILY LOW:",      // [44] Daily low temp
+      "",                // [45] empty for offset 45
+      "",                // [46] empty for offset 46
+      "",                // [47] empty for offset 47
+      "",                // [48] empty for offset 48
+      "",                // [49] empty for offset 49
+      "",                // [50] empty for offset 50
+      "",                // [51] empty for offset 51
+      "",                // [52] empty for offset 52
+      "TEMPERATURE:",    // [53] Temperature
+      "PRECIPITATION:",  // [54] Precipitation
+      "NEXT SUN EVENT:", // [55] Next sun event
+      "",                // [56] empty for offset 56
+      "NEXT CAL EVENT:", // [57] Time of the next Calendar Event
+      "",                // [58] empty for offset 58
+      "PULSE OX:"        // [59] Pulse Ox
+      ]
+    </jsonData>
+</resources>
+

--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -1741,206 +1741,36 @@ class Segment34View extends WatchUi.WatchFace {
         return val;
     }
 
-    hidden function getComplicationDesc(complicationType, labelSize as Number) as String {
-        // labelSize 1 = short
-        // labelSize 2 = mid
-        // labelSize 3 = long
-        var desc = "";
+    hidden function getComplicationDesc(complicationType as Integer, labelSize as Integer) as String {
+        /* Handle special cases or return from the array */
+        switch (complicationType) {
+            case 10:
+                if(Activity.getActivityInfo().currentHeartRate == null) {
+                    var hrDesc = [ "HR:", "LAST HR:", "LAST HR:" ];
+                    return hrDesc[labelSize - 1];
+                } else {
+                    var hrDesc = [ "HR:", "LIVE HR:", "LIVE HR:" ];
+                    return hrDesc[labelSize - 1];
+                }
+            case 16:
+                return Lang.format("$1$:", [propTzName1.toUpper()]);
+            case 41:
+                return Lang.format("$1$:", [propTzName2.toUpper()]);
+            default:
+                var labelResourceId = null as ResourceId;
 
-        if(complicationType == 0) { // Active min / week
-            if(labelSize == 1) { desc = "W MIN:"; }
-            if(labelSize == 2) { desc = "WEEK MIN:"; }
-            if(labelSize == 3) { desc = "WEEK ACT MIN:"; }
-        } else if(complicationType == 1) { // Active min / day
-            if(labelSize == 1) { desc = "D MIN:"; }
-            if(labelSize == 2) { desc = "MIN TODAY:"; }
-            if(labelSize == 3) { desc = "DAY ACT MIN:"; }
-        } else if(complicationType == 2) { // distance (km) / day
-            if(labelSize == 1) { desc = "D KM:"; }
-            if(labelSize == 2) { desc = "KM TODAY:"; }
-            if(labelSize == 3) { desc = "KM TODAY:"; }
-        } else if(complicationType == 3) { // distance (miles) / day
-            if(labelSize == 1) { desc = "D MI:"; }
-            if(labelSize == 2) { desc = "MI TODAY:"; }
-            if(labelSize == 3) { desc = "MILES TODAY:"; }
-        } else if(complicationType == 4) { // floors climbed / day
-            if(labelSize == 1) { desc = "FLRS:"; }
-            if(labelSize == 2) { desc = "FLOORS:"; }
-            if(labelSize == 3) { desc = "FLOORS:"; }
-        } else if(complicationType == 5) { // meters climbed / day
-            if(labelSize == 1) { desc = "CLIMB:"; }
-            if(labelSize == 2) { desc = "M CLIMBED:"; }
-            if(labelSize == 3) { desc = "M CLIMBED:"; }
-        } else if(complicationType == 6) { // Time to Recovery (h)
-            if(labelSize == 1) { desc = "RECOV:"; }
-            if(labelSize == 2) { desc = "RECOV HRS:"; }
-            if(labelSize == 3) { desc = "RECOVERY HRS:"; }
-        } else if(complicationType == 7) { // VO2 Max Running
-            if(labelSize == 1) { desc = "V02:"; }
-            if(labelSize == 2) { desc = "V02 MAX:"; }
-            if(labelSize == 3) { desc = "RUN V02 MAX:"; }
-        } else if(complicationType == 8) { // VO2 Max Cycling
-            if(labelSize == 1) { desc = "V02:"; }
-            if(labelSize == 2) { desc = "V02 MAX:"; }
-            if(labelSize == 3) { desc = "BIKE V02 MAX:"; }
-        } else if(complicationType == 9) { // Respiration rate
-            if(labelSize == 1) { desc = "RESP:"; }
-            if(labelSize == 2) { desc = "RESP RATE:"; }
-            if(labelSize == 3) { desc = "RESP. RATE:"; }
-        } else if(complicationType == 10) { // HR
-            var activityInfo = Activity.getActivityInfo();
-            var sample = activityInfo.currentHeartRate;
-            if(sample == null) {
-                if(labelSize == 1) { desc = "HR:"; }
-                if(labelSize == 2) { desc = "LAST HR:"; }
-                if(labelSize == 3) { desc = "LAST HR:"; }
-            } else {
-                if(labelSize == 1) { desc = "HR:"; }
-                if(labelSize == 2) { desc = "LIVE HR:"; }
-                if(labelSize == 3) { desc = "LIVE HR:"; }
-            }
-        } else if(complicationType == 11) { // Calories / day
-            if(labelSize == 1) { desc = "CAL:"; }
-            if(labelSize == 2) { desc = "CALORIES:"; }
-            if(labelSize == 3) { desc = "DLY CALORIES:"; }
-        } else if(complicationType == 12) { // Altitude (m)
-            if(labelSize == 1) { desc = "ALT:"; }
-            if(labelSize == 2) { desc = "ALTITUDE:"; }
-            if(labelSize == 3) { desc = "ALTITUDE M:"; }
-        } else if(complicationType == 13) { // Stress
-            if(labelSize == 1) { desc = "STRSS:"; }
-            if(labelSize == 2) { desc = "STRESS:"; }
-            if(labelSize == 3) { desc = "STRESS:"; }
-        } else if(complicationType == 14) { // Body battery
-            if(labelSize == 1) { desc = "B BAT:"; }
-            if(labelSize == 2) { desc = "BODY BATT:"; }
-            if(labelSize == 3) { desc = "BODY BATTERY:"; }
-        } else if(complicationType == 15) { // Altitude (ft)
-            if(labelSize == 1) { desc = "ALT:"; }
-            if(labelSize == 2) { desc = "ALTITUDE:"; }
-            if(labelSize == 3) { desc = "ALTITUDE FT:"; }
-        } else if(complicationType == 16) { // Alt TZ 1:
-            desc = Lang.format("$1$:", [propTzName1.toUpper()]);
-        } else if(complicationType == 17) { // Steps / day
-            if(labelSize == 1) { desc = "STEPS:"; }
-            if(labelSize == 2) { desc = "STEPS:"; }
-            if(labelSize == 3) { desc = "STEPS:"; }
-        } else if(complicationType == 18) { // Distance (m) / day
-            if(labelSize == 1) { desc = "DIST:"; }
-            if(labelSize == 2) { desc = "M TODAY:"; }
-            if(labelSize == 3) { desc = "METERS TODAY:"; }
-        } else if(complicationType == 19) { // Wheelchair pushes
-            desc = "PUSHES:";
-        } else if(complicationType == 20) { // Weather condition
-            desc = "";
-        } else if(complicationType == 21) { // Weekly run distance (km)
-            if(labelSize == 1) { desc = "W KM:"; }
-            if(labelSize == 2) { desc = "W RUN KM:"; }
-            if(labelSize == 3) { desc = "WEEK RUN KM:"; }
-        } else if(complicationType == 22) { // Weekly run distance (miles)
-            if(labelSize == 1) { desc = "W MI:"; }
-            if(labelSize == 2) { desc = "W RUN MI:"; }
-            if(labelSize == 3) { desc = "WEEK RUN MI:"; }
-        } else if(complicationType == 23) { // Weekly bike distance (km)
-            if(labelSize == 1) { desc = "W KM:"; }
-            if(labelSize == 2) { desc = "W BIKE KM:"; }
-            if(labelSize == 3) { desc = "WEEK BIKE KM:"; }
-        } else if(complicationType == 24) { // Weekly bike distance (miles)
-            if(labelSize == 1) { desc = "W MI:"; }
-            if(labelSize == 2) { desc = "W BIKE MI:"; }
-            if(labelSize == 3) { desc = "WEEK BIKE MI:"; }
-        } else if(complicationType == 25) { // Training status
-            desc = "TRAINING:";
-        } else if(complicationType == 26) { // Barometric pressure (hPA)
-            desc = "PRESSURE:";
-        } else if(complicationType == 27) { // Weight kg
-            if(labelSize == 1) { desc = "KG:"; }
-            if(labelSize == 2) { desc = "WEIGHT:"; }
-            if(labelSize == 3) { desc = "WEIGHT KG:"; }
-        } else if(complicationType == 28) { // Weight lbs
-            if(labelSize == 1) { desc = "LBS:"; }
-            if(labelSize == 2) { desc = "WEIGHT:"; }
-            if(labelSize == 3) { desc = "WEIGHT LBS:"; }
-        } else if(complicationType == 29) { // Act Calories / day
-            if(labelSize == 1) { desc = "A CAL:"; }
-            if(labelSize == 2) { desc = "ACT. CAL:"; }
-            if(labelSize == 3) { desc = "ACT. CALORIES:"; }
-        } else if(complicationType == 30) { // Sea level pressure (hPA)
-            desc = "PRESSURE:";
-        } else if(complicationType == 31) { // Week number
-            desc = "WEEK:";
-        } else if(complicationType == 32) { // Weekly distance (km)
-            if(labelSize == 1) { desc = "W KM:"; }
-            if(labelSize == 2) { desc = "WEEK KM:"; }
-            if(labelSize == 3) { desc = "WEEK DIST KM:"; }
-        } else if(complicationType == 33) { // Weekly distance (miles)
-            if(labelSize == 1) { desc = "W MI:"; }
-            if(labelSize == 2) { desc = "WEEK MI:"; }
-            if(labelSize == 3) { desc = "WEEKLY MILES:"; }
-        } else if(complicationType == 34) { // Battery percentage
-            if(labelSize == 1) { desc = "BATT:"; }
-            if(labelSize == 2) { desc = "BATT %:"; }
-            if(labelSize == 3) { desc = "BATTERY %:"; }
-        } else if(complicationType == 35) { // Battery days remaining
-            if(labelSize == 1) { desc = "BATT D:"; }
-            if(labelSize == 2) { desc = "BATT DAYS:"; }
-            if(labelSize == 3) { desc = "BATTERY DAYS:"; }
-        } else if(complicationType == 36) { // Notification count
-            if(labelSize == 1) { desc = "NOTIFS:"; }
-            if(labelSize == 2) { desc = "NOTIFS:"; }
-            if(labelSize == 3) { desc = "NOTIFICATIONS:"; }
-        } else if(complicationType == 37) { // Solar intensity
-            if(labelSize == 1) { desc = "SUN:"; }
-            if(labelSize == 2) { desc = "SUN INT:"; }
-            if(labelSize == 3) { desc = "SUN INTENSITY:"; }
-        } else if(complicationType == 38) { // Sensor temp
-            if(labelSize == 1) { desc = "TEMP:"; }
-            if(labelSize == 2) { desc = "TEMP:"; }
-            if(labelSize == 3) { desc = "SENSOR TEMP:"; }
-        } else if(complicationType == 39) { // Sunrise
-            if(labelSize == 1) { desc = "DAWN:"; }
-            if(labelSize == 2) { desc = "SUNRISE:"; }
-            if(labelSize == 3) { desc = "SUNRISE:"; }
-        } else if(complicationType == 40) { // Sunset
-            if(labelSize == 1) { desc = "DUSK:"; }
-            if(labelSize == 2) { desc = "SUNSET:"; }
-            if(labelSize == 3) { desc = "SUNSET:"; }
-        } else if(complicationType == 41) { // Alt TZ 2:
-            desc = Lang.format("$1$:", [propTzName2.toUpper()]);
-        } else if(complicationType == 42) {
-            if(labelSize == 1) { desc = "ALARM:"; }
-            if(labelSize == 2) { desc = "ALARMS:"; }
-            if(labelSize == 3) { desc = "ALARMS:"; }
-        } else if(complicationType == 43) {
-            if(labelSize == 1) { desc = "HIGH:"; }
-            if(labelSize == 2) { desc = "DAILY HIGH:"; }
-            if(labelSize == 3) { desc = "DAILY HIGH:"; }
-        } else if(complicationType == 44) {
-            if(labelSize == 1) { desc = "LOW:"; }
-            if(labelSize == 2) { desc = "DAILY LOW:"; }
-            if(labelSize == 3) { desc = "DAILY LOW:"; }
-        } else if(complicationType == 53) {
-            if(labelSize == 1) { desc = "TEMP:"; }
-            if(labelSize == 2) { desc = "TEMP:"; }
-            if(labelSize == 3) { desc = "TEMPERATURE:"; }
-        } else if(complicationType == 54) {
-            if(labelSize == 1) { desc = "PRECIP:"; }
-            if(labelSize == 2) { desc = "PRECIP:"; }
-            if(labelSize == 3) { desc = "PRECIPITATION:"; }
-        } else if(complicationType == 55) {
-            if(labelSize == 1) { desc = "SUN:"; }
-            if(labelSize == 2) { desc = "NEXT SUN:"; }
-            if(labelSize == 3) { desc = "NEXT SUN EVENT:"; }
-        } else if(complicationType == 57) {
-            if(labelSize == 1) { desc = "CAL:"; }
-            if(labelSize == 2) { desc = "NEXT CAL:"; }
-            if(labelSize == 3) { desc = "NEXT CAL EVENT:"; }
-        } else if(complicationType == 59) {
-            if(labelSize == 1) { desc = "OX:"; }
-            if(labelSize == 2) { desc = "PULSE OX:"; }
-            if(labelSize == 3) { desc = "PULSE OX:"; }
+                /* TODO : read from JSON */
+                switch (labelSize) {
+                    case 1: labelResourceId = Rez.JsonData.shortLabels; break;
+                    case 2: labelResourceId = Rez.JsonData.midLabels;   break;
+                    case 3: labelResourceId = Rez.JsonData.longLabels;  break;
+                    /* Invalid size, return nothing */
+                    default: return "";
+                }
+
+                var arrayJsonDesc = Application.loadResource(labelResourceId) as Array<String>;
+                return arrayJsonDesc[complicationType];
         }
-        return desc;
     }
 
     hidden function getComplicationUnit(complicationType) as String {

--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -41,6 +41,8 @@ class Segment34View extends WatchUi.WatchFace {
     private var doesPartialUpdate as Boolean = false;
     private var lastUpdate as Number or Null = null;
     private var canBurnIn as Boolean = false;
+
+    private var screenWidth as Integer = 0;
     private var screenHeight as Number = 0;
     private var previousEssentialsVis as Boolean or Null = null;
     private var batt as Number = 0;
@@ -128,6 +130,25 @@ class Segment34View extends WatchUi.WatchFace {
     private var propTzName2 as String = "";
     private var propWeekOffset as Number = 0;
     private var propLabelVisibility as Number = 0;
+
+    /* Complication data */
+
+    /* Top Data */
+    private var sunriseFieldDesc as String = "";
+    private var sunsetFieldDesc as String = "";
+
+    /* Bottom data */
+    private var leftCompLabel as String = "";
+    private var leftCompWidth as Integer = 0;
+    private var leftCompLabelSize as Integer = 2;
+
+    private var centerCompLabel as String = "";
+    private var centerCompWidth as Integer = 0;
+    private var centerCompLabelSize as Integer = 2;
+
+    private var rightCompLabel as String = "";
+    private var rightCompWidth as Integer = 0;
+    private var rightCompLabelSize as Integer = 3;
 
     function initialize() {
         WatchFace.initialize();
@@ -365,6 +386,9 @@ class Segment34View extends WatchUi.WatchFace {
             propOldNightColorTheme = propNightColorTheme;
         }
 
+        /* Update the settings for all complications */
+        updateComplicationsData();
+
         var fontVariant = Application.Properties.getValue("smallFontVariant") as Number;
         // Only load the font we need for this watch size
         if(screenHeight == 240 or screenHeight == 260 or screenHeight == 280) {
@@ -524,6 +548,52 @@ class Segment34View extends WatchUi.WatchFace {
         }
 
         previousEssentialsVis = awake;
+    }
+
+    /* For each complication, update description, unit, and update method */
+    hidden function updateComplicationsData() as Void {
+        /*** Top Complications ***/
+
+        /* Sun events */
+        if(propSunriseFieldShows == -2) {
+            sunriseFieldDesc = "";
+        } else {
+            sunriseFieldDesc = getComplicationDesc(propSunriseFieldShows, 1);
+        }
+
+        if(propSunsetFieldShows == -2) {
+            sunsetFieldDesc = "";
+        } else {
+            sunsetFieldDesc = getComplicationDesc(propSunsetFieldShows, 1);
+        }
+
+        /*** Bottom Complications ***/
+        /* Left label */
+        leftCompWidth = 3;
+        leftCompLabelSize = 2;
+        if(screenWidth > 450) {
+            leftCompWidth = 4;
+            leftCompLabelSize = 3;
+        }
+        leftCompLabel = getComplicationDesc(propLeftValueShows, leftCompLabelSize);
+
+        /* Center label */
+        centerCompWidth = 3;
+        centerCompLabelSize = 2;
+        if(screenWidth > 450) {
+            centerCompWidth = 4;
+            centerCompLabelSize = 3;
+        }
+        centerCompLabel = getComplicationDesc(propMiddleValueShows, centerCompLabelSize);
+
+        /* Right label */
+        rightCompWidth = 4;
+        rightCompLabelSize = 3;
+        if(screenWidth == 240) {
+            rightCompWidth = 3;
+            rightCompLabelSize = 2;
+        }
+        rightCompLabel = getComplicationDesc(propRightValueShows, rightCompLabelSize);
     }
 
     hidden function setVisibility2(setting as Number, label as Text, bg as Text) as Void {
@@ -1021,18 +1091,18 @@ class Segment34View extends WatchUi.WatchFace {
 
     hidden function setSunUpDown(dc as Dc) as Void {
         if(propSunriseFieldShows == -2) {
-            dDawn.setText("");
+            dDawn.setText(getLiveComplicationDesc(propSunriseFieldShows, 1, sunriseFieldDesc));
             dSunUpLabel.setText("");
         } else {
-            dDawn.setText(getComplicationDesc(propSunriseFieldShows, 1));
+            dDawn.setText(getLiveComplicationDesc(propSunriseFieldShows, 1, sunriseFieldDesc));
             dSunUpLabel.setText(getComplicationValue(propSunriseFieldShows, 5));
         }
 
         if(propSunsetFieldShows == -2) {
-            dDusk.setText("");
+            dDusk.setText(getLiveComplicationDesc(propSunsetFieldShows, 1, sunsetFieldDesc));
             dSunDownLabel.setText("");
         } else {
-            dDusk.setText(getComplicationDesc(propSunsetFieldShows, 1));
+            dDusk.setText(getLiveComplicationDesc(propSunsetFieldShows, 1, sunsetFieldDesc));
             dSunDownLabel.setText(getComplicationValue(propSunsetFieldShows, 5));
             // hide labels if so configured
             if (propLabelVisibility == 1 or propLabelVisibility == 2) {
@@ -1275,32 +1345,14 @@ class Segment34View extends WatchUi.WatchFace {
     }
 
     hidden function setBottomFields(dc as Dc) as Void {
-        var left_width = 3;
-        var left_label_size = 2;
-        if(dc.getWidth() > 450) {
-            left_width = 4;
-            left_label_size = 3;
-        }
-        dTtrDesc.setText(getComplicationDesc(propLeftValueShows, left_label_size));
-        dTtrLabel.setText(getComplicationValue(propLeftValueShows, left_width));
+        dTtrDesc.setText(getLiveComplicationDesc(propLeftValueShows, leftCompLabelSize, leftCompLabel));
+        dTtrLabel.setText(getComplicationValue(propLeftValueShows, leftCompWidth));
 
-        var mid_width = 3;
-        var mid_label_size = 2;
-        if(dc.getWidth() > 450) {
-            mid_width = 4;
-            mid_label_size = 3;
-        }
-        dHrDesc.setText(getComplicationDesc(propMiddleValueShows, mid_label_size));
-        dHrLabel.setText(getComplicationValue(propMiddleValueShows, mid_width));
+        dHrDesc.setText(getLiveComplicationDesc(propMiddleValueShows, centerCompLabelSize, centerCompLabel));
+        dHrLabel.setText(getComplicationValue(propMiddleValueShows, centerCompWidth));
 
-        var right_width = 4;
-        var right_label_size = 3;
-        if(dc.getWidth() == 240) {
-            right_width = 3;
-            right_label_size = 2;
-        }
-        dActiveDesc.setText(getComplicationDesc(propRightValueShows, right_label_size));
-        dActiveLabel.setText(getComplicationValue(propRightValueShows, right_width));
+        dActiveDesc.setText(getLiveComplicationDesc(propRightValueShows, rightCompLabelSize, rightCompLabel));
+        dActiveLabel.setText(getComplicationValue(propRightValueShows, rightCompWidth));
 
         // hide labels if so configured
        if (propLabelVisibility == 1 or propLabelVisibility == 3) {
@@ -1744,14 +1796,6 @@ class Segment34View extends WatchUi.WatchFace {
     hidden function getComplicationDesc(complicationType as Integer, labelSize as Integer) as String {
         /* Handle special cases or return from the array */
         switch (complicationType) {
-            case 10:
-                if(Activity.getActivityInfo().currentHeartRate == null) {
-                    var hrDesc = [ "HR:", "LAST HR:", "LAST HR:" ];
-                    return hrDesc[labelSize - 1];
-                } else {
-                    var hrDesc = [ "HR:", "LIVE HR:", "LIVE HR:" ];
-                    return hrDesc[labelSize - 1];
-                }
             case 16:
                 return Lang.format("$1$:", [propTzName1.toUpper()]);
             case 41:
@@ -1770,6 +1814,21 @@ class Segment34View extends WatchUi.WatchFace {
 
                 var arrayJsonDesc = Application.loadResource(labelResourceId) as Array<String>;
                 return arrayJsonDesc[complicationType];
+        }
+    }
+
+    hidden function getLiveComplicationDesc(complicationType as Integer, labelSize as Number, currentValue as String) as String {
+        /* Handle special cases here */
+        switch (complicationType) {
+            case 10:
+                if(Activity.getActivityInfo().currentHeartRate == null) {
+                    var hrDesc = [ "HR:", "LAST HR:", "LAST HR:" ];
+                    return hrDesc[labelSize - 1];
+                } else {
+                    var hrDesc = [ "HR:", "LIVE HR:", "LIVE HR:" ];
+                    return hrDesc[labelSize - 1];
+                }
+            default: return currentValue;
         }
     }
 


### PR DESCRIPTION
This PR follows the same goal as the previous one (#23) : reducing memory usage while not impacting CPU.

First commit : (35649e5)
* Stored label data outside of code in JSON data
* Loading resources each time a label is updated --> CPU/Flash intensive, so not good enough.

Second commit : (3c3a7b2)
* Only access data when settings are changed, compute and store all data required to draw labels
* Handle special cases of live labels (HR so far)

_Edit : this PR has been split in two to limit the impacts and modifications and ease the reviewing process_

The main gain in this PR is the memory usage which drops to 75kB (max 80kB) for models like the Fenix 6S and to 56kB (max 62kB) for models like Forerunner 965.