### PR TITLE
Prevent empty segments in join results

### DIFF
--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -1848,6 +1848,9 @@ class Segment34View extends WatchUi.WatchFace {
     hidden function join(array as Array<String>) as String {
         var ret = "";
         for(var i=0; i<array.size(); i++) {
+            if(array[i].equals("")) {
+                continue;
+            }
             if(ret.equals("")) {
                 ret = array[i];
             } else {


### PR DESCRIPTION
Hi, I encountered a `6C, , 14C/3C` line for complication 52 earlier which was due to no wind speed being available. This PR should fix that empty segment for any join.

If you'd rather see 0 windspeed in that case, I can create PR for that too/instead.