### PR TITLE
Use buffered bitmap on supported devices

### DIFF
--- a/source/Segment34View.mc
+++ b/source/Segment34View.mc
@@ -3365,14 +3365,15 @@ class Segment34View extends WatchUi.WatchFace {
         // Original single field behavior
         var step_width = 0;
         if(screenHeight == 240) {
-            step_width = drawDataField(dc, centerX - 19, bottomFiveY + 3, 0, null, values[:dataBottom], 5, fontBottomData, bottomDataWidth * 5);
+            step_width = drawDataField(dc, centerX - 19, bottomFiveY + 3, 0, null, values[:dataBottom], 5, false);
         } else {
-            step_width = drawDataField(dc, centerX, bottomFiveY, 0, null, values[:dataBottom], 5, fontBottomData, bottomDataWidth * 5);
+            step_width = drawDataField(dc, centerX, bottomFiveY, 0, null, values[:dataBottom], 5, false);
         }
 
         // Draw icons
         dc.setColor(themeColors[dataVal], Graphics.COLOR_TRANSPARENT);
         if(screenHeight == 240) { step_width += 30; }
+        
         dc.drawText(centerX - (step_width / 2) - (marginX / 2), bottomFiveY + (largeDataHeight / 2) + iconYAdj, fontIcons, values[:dataIcon1], Graphics.TEXT_JUSTIFY_RIGHT | Graphics.TEXT_JUSTIFY_VCENTER);
         dc.drawText(centerX + (step_width / 2) + (marginX / 2) - 2, bottomFiveY + (largeDataHeight / 2) + iconYAdj, fontIcons, values[:dataIcon2], Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER);
     }


### PR DESCRIPTION
This PR refactors the primary rendering pipeline to utilize an off-screen BufferedBitmap for static UI elements. Previously, the watch face employed a "painter's algorithm," redrawing every background segment (####) and field label (HR, STEPS) on every single frame. This redundant drawing was consuming ~113ms per update, significantly impacting battery life.

The new approach caches these static elements into a buffer (on supported devices) and blits them once per frame, overlaying only the dynamic data. While this strategy increases runtime memory usage on supported devices, it is strictly gated to models with sufficient RAM (e.g., AMOLED/System 4+) that can afford the allocation without risk.

Key Changes

Layered Rendering: Introduced offscreenBuffer to cache static elements (labels, background grids).

Draw Mode Split: Refactored drawWatchface into drawWatchfaceLayers, supporting modeStatic (buffer generation) and modeDynamic (per-frame updates).

Legacy Fallback: Implemented feature detection for Graphics.createBufferedBitmap. Devices lacking CIQ 4.0 support or reporting isLowMem will gracefully degrade to the legacy direct-draw method.

Argument Limit Workaround: Refactored drawDataField to use a class-level mDrawMode variable and consolidated font arguments, ensuring compatibility with the strict 10-argument limit on older VMs (e.g., Fenix 6).

Visual Fidelity: Moved high-color gradients and clock backgrounds back to the dynamic layer to prevent palette posterization and sub-pixel alignment drift.

Performance Impact Profiling conducted on a 15-second run:

drawText calls: Reduced from ~405 to ~200 per update (~50% reduction).

Total Render Time: Reduced from ~113ms to ~74ms (~35% reduction).

CPU Sleep: Gained ~40ms of additional sleep time per second.

Profiler was also run for 3 min on a F847AMOLED and F6Solar to ensure all works correctly and there are no crashes.

Device Compatibility

AMOLED / High RAM (Fenix 8, Epix): Full buffering enabled. Higher memory footprint is within acceptable limits for these devices.

MIP / Low RAM (Fenix 6, Instinct): Automatic fallback to legacy rendering to prevent OOM crashes.